### PR TITLE
[BUGFIX] Fix for array key 'workspaceName'

### DIFF
--- a/Classes/Flowpack/SimpleSearch/ContentRepositoryAdaptor/Command/NodeIndexCommandController.php
+++ b/Classes/Flowpack/SimpleSearch/ContentRepositoryAdaptor/Command/NodeIndexCommandController.php
@@ -80,7 +80,7 @@ class NodeIndexCommandController extends CommandController {
 	 */
 	protected function indexWorkspace($workspaceName) {
 		foreach ($this->calculateDimensionCombinations() as $combination) {
-			$context = $this->contextFactory->create(array('workspace' => $workspaceName, 'dimensions' => $combination));
+			$context = $this->contextFactory->create(array('workspaceName' => $workspaceName, 'dimensions' => $combination));
 			$rootNode = $context->getRootNode();
 
 			$this->traverseNodes($rootNode);


### PR DESCRIPTION
only live contexts were factored because of the 
different key name for the workspacename in the 
contextProperties which is merged in 
mergeContextPropertiesWithDefaults()
