### PR TITLE
Remove UNIX date indexing configuration

### DIFF
--- a/Configuration/Settings.yaml
+++ b/Configuration/Settings.yaml
@@ -2,8 +2,6 @@ TYPO3:
   TYPO3CR:
     Search:
       defaultConfigurationPerType:
-        date:
-          indexing: "${(value ? Date.format(value, 'U') : null)}"
         references:
           indexing: "${'#' + Array.join(Indexing.convertArrayOfNodesToArrayOfNodeIdentifiers(value), '#') + '#'}"
       defaultContext:


### PR DESCRIPTION
Using UNIX date format creates problems with sorting news before 2001 (and older than 2026).
