### PR TITLE
FEATURE: add comparison methods for >, >=, <, <=

### DIFF
--- a/Classes/Flowpack/SimpleSearch/ContentRepositoryAdaptor/Search/SqLiteQueryBuilder.php
+++ b/Classes/Flowpack/SimpleSearch/ContentRepositoryAdaptor/Search/SqLiteQueryBuilder.php
@@ -110,19 +110,67 @@ class SqLiteQueryBuilder extends \Flowpack\SimpleSearch\Search\SqLiteQueryBuilde
 	}
 
 	/**
-	 * add a greater than query for a given datetime property
+	 * add a greater than query for a given property
 	 *
 	 * @param $propertyName
 	 * @param $propertyValue
 	 * @param string $format
 	 * @return QueryBuilder
 	 */
-	public function greaterThanDatetime($propertyName, $propertyValue, $format = '%Y-%m-%d %H:%M:%S') {
+	public function greaterThan($propertyName, $propertyValue) {
 		if ($propertyValue instanceof NodeInterface) {
 			$propertyValue = $propertyValue->getIdentifier();
 		}
 
-		return parent::greaterThanDatetime($propertyName, $propertyValue, $format);
+		return parent::greaterThan($propertyName, $propertyValue);
+	}
+
+	/**
+	 * add a greater than or equal query for a given property
+	 *
+	 * @param $propertyName
+	 * @param $propertyValue
+	 * @param string $format
+	 * @return QueryBuilder
+	 */
+	public function greaterThanOrEqual($propertyName, $propertyValue) {
+		if ($propertyValue instanceof NodeInterface) {
+			$propertyValue = $propertyValue->getIdentifier();
+		}
+
+		return parent::greaterThanOrEqual($propertyName, $propertyValue);
+	}
+
+	/**
+	 * add a less than query for a given property
+	 *
+	 * @param $propertyName
+	 * @param $propertyValue
+	 * @param string $format
+	 * @return QueryBuilder
+	 */
+	public function lessThan($propertyName, $propertyValue) {
+		if ($propertyValue instanceof NodeInterface) {
+			$propertyValue = $propertyValue->getIdentifier();
+		}
+
+		return parent::lessThan($propertyName, $propertyValue);
+	}
+
+	/**
+	 * add a less than query for a given property
+	 *
+	 * @param $propertyName
+	 * @param $propertyValue
+	 * @param string $format
+	 * @return QueryBuilder
+	 */
+	public function lessThanOrEqual($propertyName, $propertyValue) {
+		if ($propertyValue instanceof NodeInterface) {
+			$propertyValue = $propertyValue->getIdentifier();
+		}
+
+		return parent::lessThanOrEqual($propertyName, $propertyValue);
 	}
 
 	/**

--- a/Classes/Flowpack/SimpleSearch/ContentRepositoryAdaptor/Search/SqLiteQueryBuilder.php
+++ b/Classes/Flowpack/SimpleSearch/ContentRepositoryAdaptor/Search/SqLiteQueryBuilder.php
@@ -110,6 +110,22 @@ class SqLiteQueryBuilder extends \Flowpack\SimpleSearch\Search\SqLiteQueryBuilde
 	}
 
 	/**
+	 * add a greater than query for a given datetime property
+	 *
+	 * @param $propertyName
+	 * @param $propertyValue
+	 * @param string $format
+	 * @return QueryBuilder
+	 */
+	public function greaterThanDatetime($propertyName, $propertyValue, $format = '%Y-%m-%d %H:%M:%S') {
+		if ($propertyValue instanceof NodeInterface) {
+			$propertyValue = $propertyValue->getIdentifier();
+		}
+
+		return parent::greaterThanDatetime($propertyName, $propertyValue, $format);
+	}
+
+	/**
 	 * Execute the query and return the list of nodes as result
 	 *
 	 * @return array<\TYPO3\TYPO3CR\Domain\Model\NodeInterface>

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
     "require": {
         "typo3/typo3cr": "*",
         "typo3/flow": "*",
-        "flowpack/simplesearch": "^1.3.0",
+        "flowpack/simplesearch": "dev-master",
         "typo3/typo3cr-search": "*",
         "typo3/neos": "*"
     },


### PR DESCRIPTION
Add comparison methods for greaterThan, greaterThanOrEqual, lessThan, lessThanOrEqual.

With this feature it is possible to filter search query in typoscript with comparison methods. For example you can filter nodes with a date property.

**Event.List.ts2**

```
prototype(My.Site:Event.List) {
    today = ${Date.parse('00:00', 'H:i')}
    baseQuery = ${Search.query(site).nodeType('My.Site:Event').greaterThan('startDate', this.today)}
}
```
