### PR TITLE
BUGFIX Catch exception if parent is not available

### DIFF
--- a/Classes/Indexer/NodeIndexer.php
+++ b/Classes/Indexer/NodeIndexer.php
@@ -249,13 +249,17 @@ class NodeIndexer extends AbstractNodeIndexer
             return null;
         }
 
-        $currentNode = $node->findParentNode();
-        while ($currentNode !== null) {
-            if (in_array($currentNode->getNodeType()->getName(), $this->fulltextRootNodeTypes, true)) {
-                return $currentNode;
-            }
+        try {
+            $currentNode = $node->findParentNode();
+            while ($currentNode !== null) {
+                if (in_array($currentNode->getNodeType()->getName(), $this->fulltextRootNodeTypes, true)) {
+                    return $currentNode;
+                }
 
-            $currentNode = $currentNode->findParentNode();
+                $currentNode = $currentNode->findParentNode();
+            }
+        } catch (NodeException) {
+            return null;
         }
 
         return null;


### PR DESCRIPTION
If parent node is not found (e.g hidden node) a `NodeException` is thrown, which leads to a critial error. Instead of the error the exception needs to get caught and handled with a `null` response.

This is bug caused by to the refactoring for Neos 7 upgrade, as the old `getParent` method returned `null` and didn't threw an exception:
https://github.com/Flowpack/Flowpack.SimpleSearch.ContentRepositoryAdaptor/pull/39/files#diff-88acc12ebeb4d9a9a63c7ce0e321878e38ab59d0815716450d91e6acbb8762f0R251-R257