### PR TITLE
FEATURE: Add support for excluding NodeTypes from indexing

### DIFF
--- a/Classes/Service/NodeTypeIndexingConfiguration.php
+++ b/Classes/Service/NodeTypeIndexingConfiguration.php
@@ -1,0 +1,77 @@
+<?php
+declare(strict_types=1);
+
+namespace Flowpack\SimpleSearch\ContentRepositoryAdaptor\Service;
+
+/*
+ * This file is part of the Flowpack.ElasticSearch.ContentRepositoryAdaptor package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use Neos\ContentRepository\Domain\Model\NodeType;
+use Neos\ContentRepository\Domain\Service\NodeTypeManager;
+use Neos\Flow\Annotations as Flow;
+
+/**
+ * @Flow\Scope("singleton")
+ */
+final class NodeTypeIndexingConfiguration
+{
+    /**
+     * @var array
+     * @Flow\InjectConfiguration(path="defaultConfigurationPerNodeType", package="Neos.ContentRepository.Search")
+     */
+    protected $settings;
+
+    /**
+     * @Flow\Inject
+     * @var NodeTypeManager
+     */
+    protected $nodeTypeManager;
+
+    /**
+     * @param NodeType $nodeType
+     * @return bool
+     */
+    public function isIndexable(NodeType $nodeType): bool
+    {
+        if ($this->settings === null || !is_array($this->settings)) {
+            return true;
+        }
+
+        if (isset($this->settings[$nodeType->getName()]['indexed'])) {
+            return (bool)$this->settings[$nodeType->getName()]['indexed'];
+        }
+
+        $nodeTypeParts = explode(':', $nodeType->getName());
+        $namespace = reset($nodeTypeParts) . ':*';
+        if (isset($this->settings[$namespace]['indexed'])) {
+            return (bool)$this->settings[$namespace]['indexed'];
+        }
+        if (isset($this->settings['*']['indexed'])) {
+            return (bool)$this->settings['*']['indexed'];
+        }
+
+        return false;
+    }
+
+    /**
+     * @return array
+     * @throws Exception
+     */
+    public function getIndexableConfiguration(): array
+    {
+        $nodeConfigurations = [];
+        /** @var NodeType $nodeType */
+        foreach ($this->nodeTypeManager->getNodeTypes(false) as $nodeType) {
+            $nodeConfigurations[$nodeType->getName()] = $this->isIndexable($nodeType);
+        }
+
+        return $nodeConfigurations;
+    }
+}

--- a/Configuration/Testing/NodeTypes.yaml
+++ b/Configuration/Testing/NodeTypes.yaml
@@ -1,0 +1,7 @@
+'Flowpack.SimpleSearch.ContentRepositoryAdaptor:BaseType':
+  superTypes: {  }
+'Flowpack.SimpleSearch.ContentRepositoryAdaptor:Type1':
+  superTypes:
+    'Flowpack.SimpleSearch.ContentRepositoryAdaptor:BaseType': true
+'Flowpack.SimpleSearch.ContentRepositoryAdaptor:Type2':
+  superTypes: {  }

--- a/Configuration/Testing/Settings.yaml
+++ b/Configuration/Testing/Settings.yaml
@@ -1,0 +1,11 @@
+Neos:
+  ContentRepository:
+    Search:
+      realtimeIndexing:
+        enabled: false
+      defaultConfigurationPerNodeType:
+        '*':
+          indexed: true
+        'Flowpack.SimpleSearch.ContentRepositoryAdaptor:Type1':
+          indexed: false
+

--- a/README.md
+++ b/README.md
@@ -48,3 +48,30 @@ and configure the DB connection as needed:
           value: '%env:DATABASE_PASSWORD%'
 
 The `arguments` are the index identifier (can be chosen freely) and the DSN.
+
+## Exclude NodeTypes from indexing
+
+By default the indexing processes all NodeTypes, but you can change this in your *Settings.yaml*:
+
+```yaml
+Neos:
+  ContentRepository:
+    Search:
+      defaultConfigurationPerNodeType:
+        '*':
+          indexed: true
+        'Neos.Neos:FallbackNode':
+          indexed: false
+        'Neos.Neos:Shortcut':
+          indexed: false
+        'Neos.Neos:ContentCollection':
+          indexed: false
+```
+
+You need to explicitly configure the individual NodeTypes (this feature does not check the Super Type configuration).
+But you  can use a special notation to configure a full namespace, `Acme.AcmeCom:*` will be applied for all node
+types in the `Acme.AcmeCom` namespace. The most specific configuration is used in this order:
+
+- NodeType name (`Neos.Neos:Shortcut`)
+- Full namespace notation (`Neos.Neos:*`)
+- Catch all (`*`)

--- a/Tests/Functional/Service/NodeTypeIndexingConfigurationTest.php
+++ b/Tests/Functional/Service/NodeTypeIndexingConfigurationTest.php
@@ -1,0 +1,79 @@
+<?php
+declare(strict_types=1);
+
+namespace Flowpack\SimpleSearch\ContentRepositoryAdaptor\Tests\Functional\Service;
+
+/*
+ * This file is part of the Flowpack.ElasticSearch.ContentRepositoryAdaptor package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use Flowpack\SimpleSearch\ContentRepositoryAdaptor\Service\NodeTypeIndexingConfiguration;
+use Neos\ContentRepository\Domain\Service\NodeTypeManager;
+use Neos\Flow\Tests\FunctionalTestCase;
+
+class NodeTypeIndexingConfigurationTest extends FunctionalTestCase
+{
+
+    /**
+     * @var NodeTypeManager
+     */
+    protected $nodeTypeManager;
+
+    /**
+     * @var NodeTypeIndexingConfiguration
+     */
+    protected $nodeTypeIndexingConfiguration;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+        $this->nodeTypeManager = $this->objectManager->get(NodeTypeManager::class);
+        $this->nodeTypeIndexingConfiguration = $this->objectManager->get(NodeTypeIndexingConfiguration::class);
+    }
+
+    public function nodeTypeDataProvider(): array
+    {
+        return [
+            'notIndexable' => [
+                'nodeTypeName' => 'Flowpack.SimpleSearch.ContentRepositoryAdaptor:Type1',
+                'expected' => false,
+            ],
+            'indexable' => [
+                'nodeTypeName' => 'Flowpack.SimpleSearch.ContentRepositoryAdaptor:Type2',
+                'expected' => true,
+            ],
+        ];
+    }
+
+    /**
+     * @test
+     * @dataProvider nodeTypeDataProvider
+     *
+     * @param string $nodeTypeName
+     * @param bool $expected
+     * @throws \Neos\ContentRepository\Exception\NodeTypeNotFoundException
+     */
+    public function isIndexable(string $nodeTypeName, bool $expected): void
+    {
+        self::assertEquals($expected, $this->nodeTypeIndexingConfiguration->isIndexable($this->nodeTypeManager->getNodeType($nodeTypeName)));
+    }
+
+    /**
+     * @test
+     * @dataProvider nodeTypeDataProvider
+     *
+     * @param string $nodeTypeName
+     * @param bool $expected
+     */
+    public function getIndexableConfiguration(string $nodeTypeName, bool $expected): void
+    {
+        $indexableConfiguration = $this->nodeTypeIndexingConfiguration->getIndexableConfiguration();
+        self::assertEquals($indexableConfiguration[$nodeTypeName], $expected);
+    }
+}


### PR DESCRIPTION
Migrate the NodeTypeIndexConfiguration from the ElasticSearchAdaptor to the SimpleSearchAdaptor

Resolves: #45