### PR TITLE
BUGFIX: Ensure properties are loaded properly or indexed again

### DIFF
--- a/Classes/Indexer/NodeIndexer.php
+++ b/Classes/Indexer/NodeIndexer.php
@@ -135,8 +135,7 @@ class NodeIndexer extends AbstractNodeIndexer
 
         $fulltextData = [];
 
-        if (isset($this->indexedNodeData[$identifier])) {
-            $properties = $this->indexClient->findOneByIdentifier($identifier);
+        if (isset($this->indexedNodeData[$identifier]) ($properties = $this->indexClient->findOneByIdentifier($identifier)) !== false) {
             unset($properties['__identifier__']);
             $properties['__workspace'] .= ', #' . ($targetWorkspaceName ?? $node->getContext()->getWorkspaceName()) . '#';
             if (array_key_exists('__dimensionshash', $properties)) {

--- a/Classes/Indexer/NodeIndexer.php
+++ b/Classes/Indexer/NodeIndexer.php
@@ -135,7 +135,7 @@ class NodeIndexer extends AbstractNodeIndexer
 
         $fulltextData = [];
 
-        if (isset($this->indexedNodeData[$identifier]) ($properties = $this->indexClient->findOneByIdentifier($identifier)) !== false) {
+        if (isset($this->indexedNodeData[$identifier]) && ($properties = $this->indexClient->findOneByIdentifier($identifier)) !== false) {
             unset($properties['__identifier__']);
             $properties['__workspace'] .= ', #' . ($targetWorkspaceName ?? $node->getContext()->getWorkspaceName()) . '#';
             if (array_key_exists('__dimensionshash', $properties)) {


### PR DESCRIPTION
In combination with e.g. ttree/dimensionkeeper where nodes in different variants are changed in same request, it leeds to cases, where data is removed from index database, but the runtime cache (indexedNodeData) still contains the regarding entry.

```
Warning: Undefined array key "__workspace" in /var/www/html/Data/Temporary/Development/SubContextDdev/Cache/Code/Flow_Object_Classes/Flowpack_SimpleSearch_ContentRepositoryAdaptor_Indexer_NodeIndexer.php line 147 - Check the logs for details
```

This change ensures, that all properties are loaded properly or get indexed again.